### PR TITLE
Use connection-dependant functions to retrieve last_id

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+	Use connection-dependant functions to retrieve last_id (emmanueldupuis)
+0.183230  2018-11-19 14:41:14+01:00 Europe/Paris
 	Fix debug mode within Anthill::Ant::spawn_perl_command()
 	Handle owner with hyphens (or space) (emmanueldupuis)
 0.152521  2015-09-09 15:40:57+02:00 Europe/Paris

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Anthill - Yet another process spawner
 
 # VERSION
 
-version 0.183230
+version 0.193290
 
 # SYNOPSIS
 
-    my $anthill = Anthill->new("sqlite-anthill.db');
+    my $anthill = Anthill->new('sqlite-anthill.db');
         $anthill
         ->ant( 'ant#1'=> [ foo, {bar => 'baz'} ] )
         ->start_args(perl_command => {
@@ -33,7 +33,7 @@ Nicolas Georges <xlat@cpan.org>
 
 # COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2015 by Nicolas Georges.
+This software is copyright (c) 2015 - 2019 by Nicolas Georges.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Anthill
 author  = Nicolas Georges <xlat@cpan.org>
 license = Perl_5
 copyright_holder = Nicolas Georges
-copyright_year   = 2015
+copyright_year   = 2015 - 2019
 
 [Git::Check]
 allow_dirty = dist.ini

--- a/lib/Anthill.pm
+++ b/lib/Anthill.pm
@@ -42,7 +42,7 @@ create table if not exists ant(
 );
 DEPLOY
 				insert  => q{insert into ant(name, args, start_args) values('${name}','${args}','${start_args}')},
-				last_id => q{select id from ant order by id desc limit 1},
+				last_id => q{select last_insert_rowid() as id},
 				select  => q{select ${field} from ant where id = ${id}},
 				update  => q{update ant set ${field}='${value}' where id = '${id}'},
 				list    => q{select id from ant ${where} order by id desc},
@@ -69,7 +69,8 @@ end
 go
 DEPLOY
 				insert  => q{insert into anthill.ant(name, args, start_args) values('${name}','${args}','${start_args}')},
-				last_id => q{select top 1 id from anthill.ant order by id desc},
+				# using SCOPE_IDENTITY() instead of IDENT_CURRENT() to prevent races between different sessions
+				last_id => q{select SCOPE_IDENTITY() as id},
 				select  => q{select ${field} from anthill.ant where id = ${id}},
 				update  => q{update anthill.ant set ${field}='${value}' where id = '${id}'},
 				list	=> q{select id from anthill.ant ${where} order by id desc},

--- a/lib/Anthill.pm
+++ b/lib/Anthill.pm
@@ -1,5 +1,6 @@
 package Anthill;
 # VERSION
+
 # ABSTRACT: Yet another process spawner
 use Modern::Perl;
 use DBIx::Simple;
@@ -158,7 +159,7 @@ Anthill - Yet another process spawner
 
 =head1 SYNOPSIS
 
-    my $anthill = Anthill->new("sqlite-anthill.db');
+    my $anthill = Anthill->new('sqlite-anthill.db');
 	$anthill
 	->ant( 'ant#1'=> [ foo, {bar => 'baz'} ] )
 	->start_args(perl_command => {

--- a/lib/Anthill/Ant.pm
+++ b/lib/Anthill/Ant.pm
@@ -1,5 +1,6 @@
 package Anthill::Ant;
 # VERSION
+
 # ABSTRACT: Anthill::Ant object
 use Modern::Perl;
 use Win32;


### PR DESCRIPTION
The use of connection-dependant functions (last_insert_rowid() for SQLite and
SCOPE_IDENTITY() for SQL Server) prevents race conditions occuring when
creating ants in different processes.